### PR TITLE
Fix hardcoding height and bottom values for dungeons

### DIFF
--- a/src/main/java/kaptainwutax/seedcracker/SeedCracker.java
+++ b/src/main/java/kaptainwutax/seedcracker/SeedCracker.java
@@ -7,6 +7,7 @@ import kaptainwutax.seedcracker.render.RenderQueue;
 import kaptainwutax.seedutils.mc.MCVersion;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.util.Formatting;
+import net.minecraft.world.World;
 
 public class SeedCracker implements ModInitializer {
 

--- a/src/main/java/kaptainwutax/seedcracker/cracker/decorator/Dungeon.java
+++ b/src/main/java/kaptainwutax/seedcracker/cracker/decorator/Dungeon.java
@@ -12,6 +12,7 @@ import kaptainwutax.seedutils.mc.MCVersion;
 import kaptainwutax.seedutils.mc.VersionMap;
 import mjtb49.hashreversals.ChunkRandomReverser;
 import net.minecraft.util.math.Vec3i;
+import net.minecraft.world.World;
 import randomreverser.call.java.FilteredSkip;
 import randomreverser.call.java.NextInt;
 import randomreverser.device.JavaRandomDevice;
@@ -55,7 +56,7 @@ public class Dungeon extends Decorator<Decorator.Config, Dungeon.Data> {
 			} else {
 				x = rand.nextInt(16);
 				z = rand.nextInt(16);
-				y = rand.nextInt(256);
+				y = rand.nextInt(data.world.getHeight());
 			}
 
 			if(y == data.blockY && x == data.offsetX && z == data.offsetZ) {
@@ -82,8 +83,8 @@ public class Dungeon extends Decorator<Decorator.Config, Dungeon.Data> {
 					&& biome != Biome.THE_VOID && biome == Biome.THE_END;
 	}
 
-	public Dungeon.Data at(int blockX, int blockY, int blockZ, Vec3i size, int[] floorCalls, Biome biome) {
-		return new Dungeon.Data(this, blockX, blockY, blockZ, size, floorCalls, biome);
+	public Dungeon.Data at(int blockX, int blockY, int blockZ, Vec3i size, int[] floorCalls, Biome biome, World world) {
+		return new Dungeon.Data(this, blockX, blockY, blockZ, size, floorCalls, biome, world);
 	}
 
 	public static class Data extends Decorator.Data<Dungeon> {
@@ -98,14 +99,16 @@ public class Dungeon extends Decorator<Decorator.Config, Dungeon.Data> {
 		public final Vec3i size;
 		public final int[] floorCalls;
 		public float bitsCount;
+		public World world;
 
-		public Data(Dungeon feature, int blockX, int blockY, int blockZ, Vec3i size, int[] floorCalls, Biome biome) {
+		public Data(Dungeon feature, int blockX, int blockY, int blockZ, Vec3i size, int[] floorCalls, Biome biome, World world) {
 			super(feature, blockX >> 4, blockZ >> 4, biome);
 			this.offsetX = blockX & 15;
 			this.blockY = blockY;
 			this.offsetZ = blockZ & 15;
 			this.size = size;
 			this.floorCalls = floorCalls;
+			this.world = world;
 
 			if(floorCalls != null) {
 				for(int call: floorCalls) {
@@ -134,7 +137,7 @@ public class Dungeon extends Decorator<Decorator.Config, Dungeon.Data> {
 			} else {
 				device.addCall(NextInt.withValue(16, this.offsetX));
 				device.addCall(NextInt.withValue(16, this.offsetZ));
-				device.addCall(NextInt.withValue(256, this.blockY));
+				device.addCall(NextInt.withValue(world.getHeight(), this.blockY - world.getBottomY()));
 			}
 
 			device.addCall(NextInt.consume(2, 2)); //Skip size.

--- a/src/main/java/kaptainwutax/seedcracker/finder/decorator/DungeonFinder.java
+++ b/src/main/java/kaptainwutax/seedcracker/finder/decorator/DungeonFinder.java
@@ -71,7 +71,7 @@ public class DungeonFinder extends BlockFinder {
         Vec3i size = this.getDungeonSize(pos);
         int[] floorCalls = this.getFloorCalls(size, pos);
 
-        Dungeon.Data data = Features.DUNGEON.at(pos.getX(), pos.getY(), pos.getZ(), size, floorCalls, BiomeFixer.swap(biome));
+        Dungeon.Data data = Features.DUNGEON.at(pos.getX(), pos.getY(), pos.getZ(), size, floorCalls, BiomeFixer.swap(biome), this.getWorld());
 
         if(SeedCracker.get().getDataStorage().addBaseData(data, data::onDataAdded)) {
             this.renderers.add(new Cube(pos, new Color(255, 0, 0)));


### PR DESCRIPTION
Worlds whose generation doesn't have a height of 256 and a bottom of 0 will not work with dungeon seed cracking. This is because the dungeon seed cracking in this mod always assumes that the generation has a height of 256 and a bottom of 0.

To fix this, just use `getHeight()` instead of 256, and subtract `getBottomY()` from the Y-position of the dungeon. We need to do this, because to generate the Y-position of the dungeon, Minecraft will do `Random.nextInt(getHeight())` and then add `getBottomY()` to the result. (You cannot specify the minimum bound with `Random.nextInt()`, and the minimum bound will always default to 0; so this is the next best thing to do.) And the reverse of adding is subtracting.

Also, to be able to use `getHeight()` and `getBottomY()`, we'll need to pass the `World` around a bit, but this is no big deal.

This makes the seed cracker mod work with the Caves & Cliffs 1.18 world generation preview data pack (which generates worlds with a height of 384 and a bottom of -64), completely flawlessly. I tested it.